### PR TITLE
Add CIs for pushing docker images on dockerhub

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -1,0 +1,70 @@
+name: Build and Push Dev Docker Images
+
+on:
+  push:
+    branches:
+      - v2.13
+      - v2.14
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+
+    strategy:
+      matrix:
+        distro: [alpine3.19, alpine3.20, bullseye, bookworm, rockylinux8]
+
+    steps:
+      - name: Extract branch name
+        id: extract_branch
+        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Checkout Dockerfiles repository
+        uses: actions/checkout@v4
+        with:
+          repository: BitnineGlobal/agensgraph-docker
+          token: ${{ secrets.GH_API_TOKEN }}
+          path: dockerfiles
+
+      - name: Pull the tarball
+        run: |
+            wget --header="Accept: application/vnd.github+json" \
+                 --header="Authorization: Bearer ${{ env.GH_API_TOKEN }}" \
+                 --header="X-GitHub-Api-Version: 2022-11-28" \
+                 -O dockerfiles/agensgraph.tar.gz \
+                 "https://api.github.com/repos/BitnineGlobal/agensgraph/tarball/${{ env.branch_name }}";
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set Docker tag
+        id: docker-tag
+        run: echo "DOCKER_TAG=dev-snapshot-${{ env.branch_name }}-${{ matrix.distro }}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+            platforms: linux/amd64,linux/arm64
+            context: dockerfiles
+            push: true
+            file: dockerfiles/${{ matrix.distro }}/Dockerfile
+            build-args: |
+                AG_TAR_FILE=agensgraph.tar.gz
+            tags: ${{ env.DOCKERHUB_USERNAME }}/agensgraph:${{ env.DOCKER_TAG }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,65 @@
+name: Build and Push Release Docker Images
+
+on:
+  release:
+    types:
+    - published
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+
+    strategy:
+      matrix:
+        distro: [alpine3.19, alpine3.20, bullseye, bookworm, rockylinux8]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Checkout Dockerfiles repository
+        uses: actions/checkout@v4
+        with:
+          repository: BitnineGlobal/agensgraph-docker
+          token: ${{ secrets.GH_API_TOKEN }}
+          path: dockerfiles
+
+      - name: Pull the tarball
+        run: |
+            wget --header="Accept: application/vnd.github+json" \
+                 --header="Authorization: Bearer ${{ env.GH_API_TOKEN }}" \
+                 --header="X-GitHub-Api-Version: 2022-11-28" \
+                 -O dockerfiles/agensgraph.tar.gz \
+                 "https://api.github.com/repos/BitnineGlobal/agensgraph/tarball/${{ github.event.release.tag_name }}"; \
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set Docker tag
+        id: docker-tag
+        run: echo "DOCKER_TAG=${{ github.event.release.tag_name }}-${{ matrix.distro }}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+            platforms: linux/amd64,linux/arm64
+            context: dockerfiles
+            push: true
+            file: dockerfiles/${{ matrix.distro }}/Dockerfile
+            build-args: |
+                AG_TAR_FILE=agensgraph.tar.gz
+            tags: ${{ env.DOCKERHUB_USERNAME }}/agensgraph:${{ env.DOCKER_TAG }}


### PR DESCRIPTION
- Two workflows are set up for pushing Docker images to Docker Hub:
- One for dev branches, tagged as dev-snapshot-{branch}-{distro}
- One for release tags, tagged as {tag}-{distro}